### PR TITLE
Getting rid of relative paths in #include

### DIFF
--- a/src/iiwa_plan_manager.cc
+++ b/src/iiwa_plan_manager.cc
@@ -44,9 +44,10 @@ void IiwaPlanManager::Run() {
 
 void IiwaPlanManager::CalcCommandFromStatus() {
   lcm_status_command_ = std::make_unique<lcm::LCM>();
-  lcm_status_command_->subscribe(
+  auto sub = lcm_status_command_->subscribe(
       config_["lcm_status_channel"].as<std::string>(),
       &IiwaPlanManager::HandleIiwaStatus, this);
+  sub->setQueueCapacity(1);
   while (true) {
     // >0 if a message was handled,
     // 0 if the function timed out,

--- a/src/plan_manager_system/CMakeLists.txt
+++ b/src/plan_manager_system/CMakeLists.txt
@@ -2,6 +2,8 @@ add_library(iiwa_plan_manager_system
         iiwa_plan_manager_system.h iiwa_plan_manager_system.cc)
 target_link_libraries(iiwa_plan_manager_system
         plan_manager_state_machine iiwa_plan_factory)
+target_include_directories(iiwa_plan_manager_system
+        PUBLIC ${PROJECT_SOURCE_DIR}/src)
 
 add_library(iiwa_plan_manager_hardware_interface
         iiwa_plan_manager_hardware_interface.h

--- a/src/plan_manager_system/iiwa_plan_manager_hardware_interface.h
+++ b/src/plan_manager_system/iiwa_plan_manager_hardware_interface.h
@@ -3,7 +3,7 @@
 #include "drake/lcm/drake_lcm.h"
 #include "drake/systems/framework/diagram_builder.h"
 
-#include "iiwa_plan_manager_system.h"
+#include "plan_manager_system/iiwa_plan_manager_system.h"
 
 class IiwaPlanManagerHardwareInterface {
 public:

--- a/src/plan_manager_system/iiwa_plan_manager_system.cc
+++ b/src/plan_manager_system/iiwa_plan_manager_system.cc
@@ -1,7 +1,7 @@
 #include "drake/common/value.h"
 #include <Eigen/Dense>
 
-#include "iiwa_plan_manager_system.h"
+#include "plan_manager_system/iiwa_plan_manager_system.h"
 
 using drake::lcmt_iiwa_command;
 using drake::lcmt_iiwa_status;

--- a/src/plan_manager_system/iiwa_plan_manager_system.h
+++ b/src/plan_manager_system/iiwa_plan_manager_system.h
@@ -4,8 +4,8 @@
 #include "drake_lcmtypes/drake/lcmt_iiwa_status.hpp"
 #include "drake_lcmtypes/drake/lcmt_robot_plan.hpp"
 
-#include "../plans/iiwa_plan_factory.h"
-#include "../state_machine/plan_manager_state_machine.h"
+#include "plans/iiwa_plan_factory.h"
+#include "state_machine/plan_manager_state_machine.h"
 
 class IiwaPlanManagerSystem : public drake::systems::LeafSystem<double> {
 public:

--- a/src/plans/CMakeLists.txt
+++ b/src/plans/CMakeLists.txt
@@ -3,7 +3,9 @@ add_library(robot_plans
         joint_space_trajectory_plan.h joint_space_trajectory_plan.cc
         task_space_trajectory_plan.h task_space_trajectory_plan.cc)
 target_link_libraries(robot_plans drake::drake)
+target_include_directories(robot_plans PRIVATE ${PROJECT_SOURCE_DIR}/src)
 
 add_library(iiwa_plan_factory iiwa_plan_factory.h iiwa_plan_factory.cc
         plan_factory_base.cc plan_factory_base.h)
 target_link_libraries(iiwa_plan_factory robot_plans)
+target_include_directories(iiwa_plan_factory PRIVATE ${PROJECT_SOURCE_DIR}/src)

--- a/src/plans/CMakeLists.txt
+++ b/src/plans/CMakeLists.txt
@@ -3,9 +3,9 @@ add_library(robot_plans
         joint_space_trajectory_plan.h joint_space_trajectory_plan.cc
         task_space_trajectory_plan.h task_space_trajectory_plan.cc)
 target_link_libraries(robot_plans drake::drake)
-target_include_directories(robot_plans PRIVATE ${PROJECT_SOURCE_DIR}/src)
+target_include_directories(robot_plans PUBLIC ${PROJECT_SOURCE_DIR}/src)
 
 add_library(iiwa_plan_factory iiwa_plan_factory.h iiwa_plan_factory.cc
         plan_factory_base.cc plan_factory_base.h)
 target_link_libraries(iiwa_plan_factory robot_plans)
-target_include_directories(iiwa_plan_factory PRIVATE ${PROJECT_SOURCE_DIR}/src)
+target_include_directories(iiwa_plan_factory PUBLIC ${PROJECT_SOURCE_DIR}/src)

--- a/src/plans/iiwa_plan_factory.h
+++ b/src/plans/iiwa_plan_factory.h
@@ -1,7 +1,7 @@
 #pragma once
-
-#include "plan_factory_base.h"
 #include <yaml-cpp/yaml.h>
+
+#include "plans/plan_factory_base.h"
 
 class IiwaPlanFactory : public PlanFactory {
 public:

--- a/src/plans/joint_space_trajectory_plan.h
+++ b/src/plans/joint_space_trajectory_plan.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "drake/common/trajectories/piecewise_polynomial.h"
-#include "plan_base.h"
+#include "plans/plan_base.h"
 
 class JointSpaceTrajectoryPlan : public PlanBase {
 public:

--- a/src/plans/plan_factory_base.h
+++ b/src/plans/plan_factory_base.h
@@ -4,7 +4,7 @@
 #include "drake_lcmtypes/drake/lcmt_robot_plan.hpp"
 #include "drake_lcmtypes/drake/lcmt_robot_state.hpp"
 
-#include "plan_base.h"
+#include "plans/plan_base.h"
 
 class PlanFactory {
 public:

--- a/src/plans/task_space_trajectory_plan.h
+++ b/src/plans/task_space_trajectory_plan.h
@@ -10,7 +10,7 @@
 #include "drake/multibody/tree/multibody_tree.h"
 #include "drake/systems/framework/context.h"
 
-#include "plan_base.h"
+#include "plans/plan_base.h"
 
 class TaskSpaceTrajectoryPlan : public PlanBase {
 public:

--- a/src/state_machine/CMakeLists.txt
+++ b/src/state_machine/CMakeLists.txt
@@ -5,3 +5,6 @@ add_library(plan_manager_state_machine
         state_running.h state_running.cc
         state_error.h state_error.cc)
 target_link_libraries(plan_manager_state_machine robot_plans)
+target_include_directories(plan_manager_state_machine PRIVATE
+        ${PROJECT_SOURCE_DIR}/src)
+

--- a/src/state_machine/CMakeLists.txt
+++ b/src/state_machine/CMakeLists.txt
@@ -5,6 +5,6 @@ add_library(plan_manager_state_machine
         state_running.h state_running.cc
         state_error.h state_error.cc)
 target_link_libraries(plan_manager_state_machine robot_plans)
-target_include_directories(plan_manager_state_machine PRIVATE
+target_include_directories(plan_manager_state_machine PUBLIC
         ${PROJECT_SOURCE_DIR}/src)
 

--- a/src/state_machine/plan_manager_state_machine.cc
+++ b/src/state_machine/plan_manager_state_machine.cc
@@ -1,6 +1,6 @@
-#include "plan_manager_state_machine.h"
-#include "state_error.h"
-#include "state_init.h"
+#include "state_machine/plan_manager_state_machine.h"
+#include "state_machine/state_error.h"
+#include "state_machine/state_init.h"
 
 using std::string;
 

--- a/src/state_machine/plan_manager_state_machine.h
+++ b/src/state_machine/plan_manager_state_machine.h
@@ -7,7 +7,7 @@
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake_lcmtypes/drake/lcmt_iiwa_status.hpp"
 
-#include "../plans/plan_base.h"
+#include "plans/plan_base.h"
 
 // TODO: this is not used right now.
 enum PlanManagerStateTypes {

--- a/src/state_machine/state_error.cc
+++ b/src/state_machine/state_error.cc
@@ -1,4 +1,4 @@
-#include "state_error.h"
+#include "state_machine/state_error.h"
 
 using std::cout;
 using std::endl;

--- a/src/state_machine/state_error.h
+++ b/src/state_machine/state_error.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "plan_manager_state_machine.h"
+#include "state_machine/plan_manager_state_machine.h"
 
 class StateError : public PlanManagerStateBase {
 public:

--- a/src/state_machine/state_idle.h
+++ b/src/state_machine/state_idle.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "plan_manager_state_machine.h"
+#include "state_machine/plan_manager_state_machine.h"
 
 class StateIdle : public PlanManagerStateBase {
 public:

--- a/src/state_machine/state_init.h
+++ b/src/state_machine/state_init.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "plan_manager_state_machine.h"
+#include "state_machine/plan_manager_state_machine.h"
 
 class StateInit : public PlanManagerStateBase {
 public:

--- a/src/state_machine/state_running.h
+++ b/src/state_machine/state_running.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "plan_manager_state_machine.h"
+#include "state_machine/plan_manager_state_machine.h"
 
 class StateRunning : public PlanManagerStateBase {
 public:


### PR DESCRIPTION
Include paths of some of the targets are changed, so that all includes start from `/src/`, no more relative paths in includes.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/robot-plan-runner/22)
<!-- Reviewable:end -->
