### PR TITLE
Some minor improvements.

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -16,3 +16,6 @@ robot_ee_body_name: "iiwa_link_7"
 # Control Parameters
 control_period: 0.005
 q_threshold: 0.05 # norm between current q and commanded q.
+
+# Print Parameters.
+print_period_seconds: 10.

--- a/src/examples/zmq_client_example.py
+++ b/src/examples/zmq_client_example.py
@@ -1,24 +1,22 @@
 import time
-import sys, argparse
 
 import numpy as np
-
 from pydrake.all import RigidTransform
 
-from plan_runner_client.zmq_client import PlanManagerZmqClient
 from plan_runner_client.calc_plan_msg import (
     calc_joint_space_plan_msg,
     calc_task_space_plan_msg
 )
+from plan_runner_client.zmq_client import PlanManagerZmqClient
 
 zmq_client = PlanManagerZmqClient()
 
 t_knots = np.array([0, 10])
 q0 = zmq_client.get_current_joint_angles()
 
-if type(q0) == type(None):
-    raise RuntimeError("No messages were detected in IIWA_STATUS. " + 
-                        "Is the simulation runnning?")
+if len(q0) == 0:
+    raise RuntimeError("No messages were detected in IIWA_STATUS. " +
+                       "Is the simulation runnning?")
 
 q_knots1 = np.zeros((2, 7))
 q_knots1[:, ] = q0
@@ -57,7 +55,7 @@ def run_task_space_plan():
     X_WE0 = zmq_client.get_current_ee_pose(frame_E)
     X_WT0 = X_WE0.multiply(X_ET)
     X_WT1 = RigidTransform(X_WT0.rotation(),
-                        X_WT0.translation() + np.array([0, 0.2, 0]))
+                           X_WT0.translation() + np.array([0, 0.2, 0]))
     plan_msg = calc_task_space_plan_msg(X_ET, [X_WT0, X_WT1], [0, 5])
     zmq_client.send_plan(plan_msg)
 
@@ -67,7 +65,8 @@ def run_joint_space_plan_loop():
     Send random joint space plan, randomly interrupt, return to home,
     and start over. 
     """
-    # TODO: support WaitForServer, which blocks until the server is in state IDLE.
+    # TODO: support WaitForServer, which blocks until the server is in state
+    #  IDLE.
     while True:
         print("plan sent")
         plan_msg = calc_joint_space_plan_msg([0, duration], q_knots1)
@@ -96,11 +95,10 @@ def generate_doc_string(test_lst):
         doc_string += "[" + test_lst[i].__name__ + "] : "
         doc_string += test_lst[i].__doc__
         doc_string += "\n"
-    return doc_string 
+    return doc_string
 
 
 if __name__ == "__main__":
-
     # New tests should be added in the list.
     test_lst = [
         run_joint_space_plan,

--- a/src/examples/zmq_client_example.py
+++ b/src/examples/zmq_client_example.py
@@ -1,4 +1,5 @@
 import time
+import argparse
 
 import numpy as np
 from pydrake.all import RigidTransform

--- a/src/plan_runner_client/zmq_client.py
+++ b/src/plan_runner_client/zmq_client.py
@@ -117,6 +117,7 @@ class PlanManagerZmqClient:
         print("plan received by server.")
 
     def wait_for_plan_to_finish(self):
+        # TODO: add timeout.
         while True:
             self.status_msg_lock.acquire()
             self.plan_msg_lock.acquire()

--- a/src/state_machine/plan_manager_state_machine.h
+++ b/src/state_machine/plan_manager_state_machine.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <queue>
 #include <yaml-cpp/yaml.h>
+#include <sstream>
 
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake_lcmtypes/drake/lcmt_iiwa_status.hpp"
@@ -144,6 +145,10 @@ public:
 
   virtual void AbortAllPlans(PlanManagerStateMachine *state_machine);
 
+  virtual const PlanBase *
+  GetCurrentPlan(PlanManagerStateMachine *state_machine, double t_now_seconds,
+                 const drake::lcmt_iiwa_status &msg_iiwa_status) const;
+
   // Pure virtual functions.
   [[nodiscard]] virtual PlanManagerStateTypes get_state_type() const = 0;
 
@@ -152,10 +157,6 @@ public:
                       const drake::lcmt_iiwa_status &msg_iiwa_status) const = 0;
   virtual void PrintCurrentState(const PlanManagerStateMachine *state_machine,
                                  double t_now_seconds) const = 0;
-
-  virtual const PlanBase *
-  GetCurrentPlan(PlanManagerStateMachine *state_machine, double t_now_seconds,
-                 const drake::lcmt_iiwa_status &msg_iiwa_status) const = 0;
 
   // Other functions.
   [[nodiscard]] const std::string &get_state_name() const {
@@ -168,6 +169,10 @@ protected:
 
   static void ChangeState(PlanManagerStateMachine *state_machine,
                           PlanManagerStateBase *new_state) {
+    std::stringstream ss;
+    ss << "[" << state_machine->state_->get_state_name() << "]" << "---->"
+       << "[" << new_state->get_state_name() << "]";
+    spdlog::info(ss.str());
     state_machine->ChangeState(new_state);
   };
 

--- a/src/state_machine/state_error.cc
+++ b/src/state_machine/state_error.cc
@@ -22,18 +22,21 @@ bool StateError::CommandHasError(const State &state, const Command &cmd,
 
 void StateError::PrintCurrentState(const PlanManagerStateMachine *state_machine,
                                    double t_now_seconds) const {
-  std::string msg("t = ");
-  msg +=
-      std::to_string(state_machine->get_state_machine_up_time(t_now_seconds));
-  msg += (". [ERROR]: ");
+  std::string msg;
+  msg += ("[ERROR]: ");
   msg += "Number of plans: ";
   msg += std::to_string(state_machine->num_plans());
-  msg += ".";
-  cout << msg << endl;
+  msg += ". t = ";
+  msg +=
+      std::to_string(state_machine->get_state_machine_up_time(t_now_seconds));
+  spdlog::critical(msg);
 }
 
 void StateError::QueueNewPlan(PlanManagerStateMachine *state_machine,
                               std::unique_ptr<PlanBase> plan) {
-  cout << "[ERROR]: received plan is discarded."
-       << "Number of plans: " << state_machine->num_plans() << "." << endl;
+  std::string msg("[ERROR]: received plan is discarded.");
+  msg += "Number of plans: ";
+  msg += std::to_string(state_machine->num_plans());
+  msg += ".";
+  spdlog::critical(msg);
 }

--- a/src/state_machine/state_error.h
+++ b/src/state_machine/state_error.h
@@ -5,12 +5,6 @@ class StateError : public PlanManagerStateBase {
 public:
   static PlanManagerStateBase *Instance();
 
-  const PlanBase *GetCurrentPlan(
-      PlanManagerStateMachine *state_machine, double t_now,
-      const drake::lcmt_iiwa_status &msg_iiwa_status) const override {
-    return nullptr;
-  };
-
   void QueueNewPlan(PlanManagerStateMachine *state_machine,
                     std::unique_ptr<PlanBase> plan) override;
 

--- a/src/state_machine/state_idle.cc
+++ b/src/state_machine/state_idle.cc
@@ -12,13 +12,6 @@ PlanManagerStateBase *StateIdle::Instance() {
   return instance_;
 }
 
-const PlanBase *StateIdle::GetCurrentPlan(
-    PlanManagerStateMachine *state_machine, double t_now,
-    const drake::lcmt_iiwa_status &msg_iiwa_status) const {
-  DRAKE_THROW_UNLESS(state_machine->num_plans() == 0);
-  return nullptr;
-}
-
 void StateIdle::QueueNewPlan(PlanManagerStateMachine *state_machine,
                              std::unique_ptr<PlanBase> plan) {
   auto &plan_queue = state_machine->get_mutable_plans_queue();
@@ -28,14 +21,14 @@ void StateIdle::QueueNewPlan(PlanManagerStateMachine *state_machine,
 
 void StateIdle::PrintCurrentState(const PlanManagerStateMachine *state_machine,
                                   double t_now_seconds) const {
-  std::string msg("t = ");
-  msg +=
-      std::to_string(state_machine->get_state_machine_up_time(t_now_seconds));
-  msg += (". [IDLE]: waiting for new plans. ");
+  std::string msg;
+  msg += ("[IDLE]: waiting for new plans. ");
   msg += "Number of plans: ";
   msg += std::to_string(state_machine->num_plans());
-  msg += ".";
-  cout << msg << endl;
+  msg += ". t = ";
+  msg +=
+      std::to_string(state_machine->get_state_machine_up_time(t_now_seconds));
+  spdlog::info(msg);
 }
 
 void StateIdle::ReceiveNewStatusMsg(

--- a/src/state_machine/state_idle.h
+++ b/src/state_machine/state_idle.h
@@ -5,11 +5,6 @@ class StateIdle : public PlanManagerStateBase {
 public:
   static PlanManagerStateBase *Instance();
 
-  const PlanBase *
-  GetCurrentPlan(PlanManagerStateMachine *state_machine,
-                 double t_now,
-                 const drake::lcmt_iiwa_status &msg_iiwa_status) const override;
-
   [[nodiscard]] bool has_received_status_msg() const override { return true; };
 
   void ReceiveNewStatusMsg(PlanManagerStateMachine *state_machine,

--- a/src/state_machine/state_init.cc
+++ b/src/state_machine/state_init.cc
@@ -12,13 +12,6 @@ PlanManagerStateBase *StateInit::Instance() {
   return instance_;
 }
 
-const PlanBase *StateInit::GetCurrentPlan(
-    PlanManagerStateMachine *state_machine, double t_now,
-    const drake::lcmt_iiwa_status &msg_iiwa_status) const {
-  DRAKE_THROW_UNLESS(state_machine->num_plans() == 0);
-  return nullptr;
-}
-
 void StateInit::ReceiveNewStatusMsg(
     PlanManagerStateMachine *state_machine,
     const drake::lcmt_iiwa_status &msg_iiwa_status) const {
@@ -28,9 +21,8 @@ void StateInit::ReceiveNewStatusMsg(
 
 void StateInit::QueueNewPlan(PlanManagerStateMachine *state_machine,
                              std::unique_ptr<PlanBase> plan) {
-  std::cout << "[INIT]: no robot status message received yet. "
-               "Received plan is discarded."
-            << std::endl;
+  spdlog::warn("[INIT]: no robot status message received yet. "
+               "Received plan is discarded.");
 }
 
 bool StateInit::CommandHasError(const State &state, const Command &cmd,
@@ -44,12 +36,12 @@ bool StateInit::CommandHasError(const State &state, const Command &cmd,
 
 void StateInit::PrintCurrentState(const PlanManagerStateMachine *state_machine,
                                   double t_now_seconds) const {
-  std::string msg("t = ");
-  msg +=
-      std::to_string(state_machine->get_state_machine_up_time(t_now_seconds));
-  msg += (". [INIT]: waiting for IIWA_STATUS. ");
+  std::string msg;
+  msg += ("[INIT]: waiting for IIWA_STATUS. ");
   msg += "Number of plans: ";
   msg += std::to_string(state_machine->num_plans());
-  msg += ".";
-  cout << msg << endl;
+  msg += ". t = ";
+  msg +=
+      std::to_string(state_machine->get_state_machine_up_time(t_now_seconds));
+  spdlog::info(msg);
 }

--- a/src/state_machine/state_init.h
+++ b/src/state_machine/state_init.h
@@ -4,9 +4,6 @@
 class StateInit : public PlanManagerStateBase {
 public:
   static PlanManagerStateBase *Instance();
-  const PlanBase *
-  GetCurrentPlan(PlanManagerStateMachine *state_machine, double t_now,
-                 const drake::lcmt_iiwa_status &msg_iiwa_status) const override;
 
   [[nodiscard]] bool has_received_status_msg() const override { return false; };
 


### PR DESCRIPTION
- Uses `spdlog` to print info to console.
- Adds print period as a parameter to the config.yml file.
- `State::GetCurrentPlan` for `INIT`, `IDLE` and `ERROR` uses the default implementation in `PlanManagerStateBase`.
- More documentation in `iiwa_plan_manager`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/robot-plan-runner/36)
<!-- Reviewable:end -->
