### PR TITLE
ChickenHead Plan.

### DIFF
--- a/src/examples/run_chicken_head_fake_msg_publisher.py
+++ b/src/examples/run_chicken_head_fake_msg_publisher.py
@@ -1,0 +1,22 @@
+import time
+import numpy as np
+
+from pydrake.all import DrakeLcm, RotationMatrix
+from pydrake.math import RollPitchYaw
+from drake import lcmt_robot_state
+
+channel_name = "X_TC"
+lcm = DrakeLcm()
+
+t0 = time.time()
+while True:
+    msg = lcmt_robot_state()
+    t = time.time()
+    msg.utime = int(t * 1e6)
+    msg.num_joints = 7
+    msg.joint_name = ["qw", "qx", "qy", "qz", "px", "py", "pz"]
+    R_TC = RollPitchYaw(0, 0, 0.2 * np.sin(t - t0)).ToRotationMatrix()
+    msg.joint_position = np.hstack([R_TC.ToQuaternion().wxyz(), np.zeros(3)])
+    lcm.Publish(channel_name, msg.encode())
+    time.sleep(0.01)
+

--- a/src/examples/run_chicken_head_plan.py
+++ b/src/examples/run_chicken_head_plan.py
@@ -11,12 +11,14 @@ n_q = 7
 X_WL7 = zmq_client.get_ee_pose_commanded(frame_L7)
 
 #%%
+# TODO: these joint names are getting ridiculous... we really need our own LCM types
+#  for plans.
 joint_names = ["qw_chicken", "qx_chicken", "qy_chicken", "qz_chicken", "px_chicken",
                "py_chicken", "pz_chicken"]
-t_knots = [0, 5.]
+t_knots = [0, 60.]
 
 msg_plan = lcmt_robot_plan()
-msg_plan.utime = round(time.time() * 1000)
+msg_plan.utime = round(time.time() * 1e6)
 msg_plan.num_states = 2
 
 for i in range(len(t_knots)):

--- a/src/examples/run_chicken_head_plan.py
+++ b/src/examples/run_chicken_head_plan.py
@@ -1,0 +1,33 @@
+import time
+
+import numpy as np
+from plan_runner_client.zmq_client import PlanManagerZmqClient
+from drake import lcmt_robot_plan, lcmt_robot_state
+
+zmq_client = PlanManagerZmqClient()
+
+frame_L7 = zmq_client.plant.GetFrameByName('iiwa_link_7')
+n_q = 7
+X_WL7 = zmq_client.get_ee_pose_commanded(frame_L7)
+
+#%%
+joint_names = ["qw_chicken", "qx_chicken", "qy_chicken", "qz_chicken", "px_chicken",
+               "py_chicken", "pz_chicken"]
+t_knots = [0, 5.]
+
+msg_plan = lcmt_robot_plan()
+msg_plan.utime = round(time.time() * 1000)
+msg_plan.num_states = 2
+
+for i in range(len(t_knots)):
+    msg_state = lcmt_robot_state()
+    msg_state.utime = int(1e6 * t_knots[i])
+    msg_state.num_joints = n_q
+    msg_state.joint_name = joint_names
+    msg_state.joint_position = np.hstack(
+        [X_WL7.rotation().ToQuaternion().wxyz(), X_WL7.translation()])
+    msg_plan.plan.append(msg_state)
+
+#%%
+zmq_client.send_plan(msg_plan)
+zmq_client.wait_for_plan_to_finish()

--- a/src/examples/simple_test.py
+++ b/src/examples/simple_test.py
@@ -28,8 +28,8 @@ X_ET = RigidTransform(RollPitchYaw(0, -np.pi / 2, 0), np.array([0, 0, 0.255]))
 
 # Step 1. Check that the correct Cartesian position is valid and kinematics
 # are working correctly.
-q_now = zmq_client.get_current_joint_angles()
-X_WE = zmq_client.get_current_ee_pose(frame_E)
+q_now = zmq_client.get_joint_angles_commanded()
+X_WE = zmq_client.get_ee_pose_commanded(frame_E)
 print("Current joint angles:")
 print(q_now)
 print("Current end-effector position:")
@@ -52,7 +52,7 @@ duration = 30
 t_knots = np.linspace(0, duration, 22)
 q_knots = np.zeros((22, 7))
 
-q_knots[0, :] = zmq_client.get_current_joint_angles()
+q_knots[0, :] = zmq_client.get_joint_angles_commanded()
 for i in range(7):
     q_knots[3 * i + 1, :] = q_knots[3 * i, :]
     q_knots[3 * i + 1, i] += 0.2
@@ -63,7 +63,6 @@ for i in range(7):
 
 plan_msg1 = calc_joint_space_plan_msg(t_knots, q_knots)
 zmq_client.send_plan(plan_msg1)
-time.sleep(1.0)
 zmq_client.wait_for_plan_to_finish()
 time.sleep(2.0)
 
@@ -72,12 +71,11 @@ duration = 2
 t_knots = np.linspace(0, duration, 2)
 q_knots = np.zeros((2, 7))
 
-q_knots[0, :] = zmq_client.get_current_joint_angles()
+q_knots[0, :] = zmq_client.get_joint_angles_commanded()
 q_knots[1, :] = [0, 0.3, 0.0, -1.75, 0.0, 1.0, 0.0]
 
 plan_msg2 = calc_joint_space_plan_msg(t_knots, q_knots)
 zmq_client.send_plan(plan_msg2)
-time.sleep(1.0)
 zmq_client.wait_for_plan_to_finish()
 
 time.sleep(2.0)
@@ -87,7 +85,7 @@ duration = 2
 t_knots = np.linspace(0, duration, 2)
 
 X_WT_lst = []
-X_WT_lst.append(zmq_client.get_current_ee_pose(frame_E))
+X_WT_lst.append(zmq_client.get_ee_pose_commanded(frame_E))
 X_WT_lst.append(RigidTransform(RollPitchYaw([0, -np.pi, 0]),
                                np.array([0.5, 0.0, 0.5])))
 
@@ -130,5 +128,4 @@ for i in range(1 + div * 6):
 
 plan_msg3 = calc_task_space_plan_msg(RigidTransform(), X_WT_lst, t_knots)
 zmq_client.send_plan(plan_msg3)
-time.sleep(1.0)
 zmq_client.wait_for_plan_to_finish()

--- a/src/examples/zmq_client_example.py
+++ b/src/examples/zmq_client_example.py
@@ -13,7 +13,7 @@ from plan_runner_client.zmq_client import PlanManagerZmqClient
 zmq_client = PlanManagerZmqClient()
 
 t_knots = np.array([0, 10])
-q0 = zmq_client.get_current_joint_angles()
+q0 = zmq_client.get_joint_angles_measured()
 
 if len(q0) == 0:
     raise RuntimeError("No messages were detected in IIWA_STATUS. " +
@@ -53,7 +53,7 @@ def run_task_space_plan():
     frame_E = zmq_client.plant.GetFrameByName('iiwa_link_7')
     X_ET = RigidTransform()
     X_ET.set_translation([0.1, 0, 0])
-    X_WE0 = zmq_client.get_current_ee_pose(frame_E)
+    X_WE0 = zmq_client.get_ee_pose_commanded(frame_E)
     X_WT0 = X_WE0.multiply(X_ET)
     X_WT1 = RigidTransform(X_WT0.rotation(),
                            X_WT0.translation() + np.array([0, 0.2, 0]))

--- a/src/examples/zmq_client_example.py
+++ b/src/examples/zmq_client_example.py
@@ -76,6 +76,7 @@ def run_joint_space_plan_loop():
         stop_duration = np.random.rand() * duration
         time.sleep(stop_duration)
         zmq_client.abort()
+        zmq_client.wait_for_plan_to_finish()
         print("plan aborted after t = {}s".format(stop_duration))
 
         # # get current robot position.

--- a/src/iiwa_plan_manager.h
+++ b/src/iiwa_plan_manager.h
@@ -6,7 +6,7 @@
 #include <zmq.hpp>
 
 #include "drake_lcmtypes/drake/lcmt_iiwa_status.hpp"
-#include "lcm/lcm-cpp.hpp"
+#include "drake/lcm/drake_lcm.h"
 
 #include "plans/iiwa_plan_factory.h"
 #include "state_machine/plan_manager_state_machine.h"
@@ -18,23 +18,24 @@ public:
   void Run();
 
 private:
+  const YAML::Node config_;
+  const std::string lcm_cmd_channel_name_;
   const double control_period_seconds_;
   mutable std::mutex mutex_state_machine_;
   std::unique_ptr<PlanManagerStateMachine> state_machine_;
   std::unordered_map<std::string, std::thread> threads_;
   std::unique_ptr<IiwaPlanFactory> plan_factory_;
 
-  const YAML::Node config_;
   // This context is used in multiple threads. zmq context should be
   // thread-safe, according to their documentation...
   zmq::context_t zmq_ctx_;
 
   // Iiwa status + command thread.
-  std::unique_ptr<lcm::LCM> lcm_status_command_;
-  void CalcCommandFromStatus();
-  void HandleIiwaStatus(const lcm::ReceiveBuffer *rbuf,
-                        const std::string &channel,
-                        const drake::lcmt_iiwa_status *status_msg);
+  std::unique_ptr<drake::lcm::DrakeLcm> owned_lcm_;
+  std::unique_ptr<drake::lcm::Subscriber<drake::lcmt_iiwa_status>>
+    iiwa_status_sub_;
+  [[noreturn]] void CalcCommandFromStatus();
+  void HandleIiwaStatus(const drake::lcmt_iiwa_status& status_msg);
 
   // Printing thread.
   [[noreturn]] void PrintStateMachineStatus() const;

--- a/src/plan_manager_system/iiwa_plan_manager_system.cc
+++ b/src/plan_manager_system/iiwa_plan_manager_system.cc
@@ -100,7 +100,7 @@ void IiwaPlanManagerSystem::CalcIiwaCommand(
   }
 
   // Check command for error.
-  if (!state_machine_->CommandHasError(s, c)) {
+  if (!state_machine_->CheckCommandForError(s, c)) {
     const int num_joints = msg_iiwa_status.num_joints;
     msg_iiwa_command.num_joints = num_joints;
     msg_iiwa_command.num_torques = num_joints;

--- a/src/plan_runner_client/zmq_client.py
+++ b/src/plan_runner_client/zmq_client.py
@@ -4,6 +4,7 @@ import sys
 import copy
 import logging
 
+import pydrake.multibody.tree
 import zmq
 import lcm
 
@@ -41,9 +42,9 @@ class IiwaPositionGetter:
         self.lc = lcm.LCM()
         sub = self.lc.subscribe("IIWA_STATUS", self.sub_callback)
         sub.set_queue_capacity(1)
-        self.iiwa_position_measured = None
+        self.iiwa_status_msg = None
         self.msg_lock = threading.Lock()
-        self.t1 = threading.Thread(target=self.update_iiwa_position_measured)
+        self.t1 = threading.Thread(target=self.update_iiwa_status)
         self.t1.start()
 
         # TODO: Set up logger (should really do it elsewhere...)
@@ -59,7 +60,7 @@ class IiwaPositionGetter:
         self.logger.info("Waiting for iiwa Status...")
         while True:
             self.msg_lock.acquire()
-            if self.iiwa_position_measured is not None:
+            if self.iiwa_status_msg is not None:
                 self.msg_lock.release()
                 break
 
@@ -70,20 +71,28 @@ class IiwaPositionGetter:
     def sub_callback(self, channel, data):
         iiwa_status_msg = lcmt_iiwa_status.decode(data)
         self.msg_lock.acquire()
-        self.iiwa_position_measured = iiwa_status_msg.joint_position_measured
+        self.iiwa_status_msg = iiwa_status_msg
         self.msg_lock.release()
 
-    def update_iiwa_position_measured(self):
+    def update_iiwa_status(self):
         while True:
             self.lc.handle()
 
     def get_iiwa_position_measured(self):
-        iiwa_position_measured = np.array([])
+        q = np.array([])
         self.msg_lock.acquire()
-        if self.iiwa_position_measured:
-            iiwa_position_measured = np.array(self.iiwa_position_measured)
+        if self.iiwa_status_msg:
+            q = np.array(self.iiwa_status_msg.joint_position_measured)
         self.msg_lock.release()
-        return iiwa_position_measured
+        return q
+
+    def get_iiwa_position_commanded(self):
+        q = np.array([])
+        self.msg_lock.acquire()
+        if self.iiwa_status_msg:
+            q = np.array(self.iiwa_status_msg.joint_position_commanded)
+        self.msg_lock.release()
+        return q
 
 
 class PlanManagerZmqClient:
@@ -138,15 +147,26 @@ class PlanManagerZmqClient:
         self.status_msg_lock.release()
         return status_msg
 
-    def get_current_ee_pose(self, frame_E):
-        context = self.plant.CreateDefaultContext()
+    def get_ee_pose_measured(self, frame_E: pydrake.multibody.tree.Frame,):
         q = self.iiwa_position_getter.get_iiwa_position_measured()
+        return self.get_ee_pose_from_joint_angles(frame_E, q)
+
+    def get_ee_pose_commanded(self, frame_E: pydrake.multibody.tree.Frame, ):
+        q = self.iiwa_position_getter.get_iiwa_position_commanded()
+        return self.get_ee_pose_from_joint_angles(frame_E, q)
+
+    def get_ee_pose_from_joint_angles(self, frame_E: pydrake.multibody.tree.Frame,
+                                      q: np.ndarray):
+        context = self.plant.CreateDefaultContext()
         self.plant.SetPositions(context, q)
         return self.plant.CalcRelativeTransform(
             context, self.plant.world_frame(), frame_E)
 
-    def get_current_joint_angles(self):
+    def get_joint_angles_measured(self):
         return self.iiwa_position_getter.get_iiwa_position_measured()
+
+    def get_joint_angles_commanded(self):
+        return self.iiwa_position_getter.get_iiwa_position_commanded()
 
     def send_plan(self, plan_msg):
         self.plan_msg_lock.acquire()
@@ -155,12 +175,15 @@ class PlanManagerZmqClient:
         self.plan_client.send(plan_msg.encode())
         msg = self.plan_client.recv()
         assert msg == b'plan_received'
-        print("plan received by server.")
+        self.iiwa_position_getter.logger.info("plan received by server.")
 
     def wait_for_plan_to_finish(self):
         # TODO: add timeout.
         while True:
             status_msg = self.get_plan_status()
+            if status_msg is None:
+                time.sleep(0.01)
+                continue
             self.plan_msg_lock.acquire()
             is_same_plan = (
                 self.last_plan_msg.utime == status_msg.utime)
@@ -175,7 +198,8 @@ class PlanManagerZmqClient:
             if is_same_plan and (is_plan_finished or is_plan_error):
                 break
             time.sleep(0.01)
-        print("Final status:", self.plan_stats_dict[status_msg.status])
+        self.iiwa_position_getter.logger.info(
+            "Final status: " + self.plan_stats_dict[status_msg.status])
 
     def abort(self):
         self.abort_client.send(b"abort")

--- a/src/plan_runner_client/zmq_client.py
+++ b/src/plan_runner_client/zmq_client.py
@@ -204,7 +204,7 @@ class PlanManagerZmqClient:
     def abort(self):
         self.abort_client.send(b"abort")
         s = self.abort_client.recv_string()
-        print(s)
+        self.iiwa_position_getter.logger.info(s)
 
 
 class SchunkManager:

--- a/src/plan_runner_client/zmq_client.py
+++ b/src/plan_runner_client/zmq_client.py
@@ -147,11 +147,11 @@ class PlanManagerZmqClient:
         self.status_msg_lock.release()
         return status_msg
 
-    def get_ee_pose_measured(self, frame_E: pydrake.multibody.tree.Frame,):
+    def get_ee_pose_measured(self, frame_E: pydrake.multibody.tree.Frame):
         q = self.iiwa_position_getter.get_iiwa_position_measured()
         return self.get_ee_pose_from_joint_angles(frame_E, q)
 
-    def get_ee_pose_commanded(self, frame_E: pydrake.multibody.tree.Frame, ):
+    def get_ee_pose_commanded(self, frame_E: pydrake.multibody.tree.Frame):
         q = self.iiwa_position_getter.get_iiwa_position_commanded()
         return self.get_ee_pose_from_joint_angles(frame_E, q)
 

--- a/src/plans/CMakeLists.txt
+++ b/src/plans/CMakeLists.txt
@@ -1,7 +1,8 @@
 add_library(robot_plans
         plan_base.h plan_base.cc
         joint_space_trajectory_plan.h joint_space_trajectory_plan.cc
-        task_space_trajectory_plan.h task_space_trajectory_plan.cc)
+        task_space_trajectory_plan.h task_space_trajectory_plan.cc
+        chicken_head_plan.h chicken_head_plan.cc)
 target_link_libraries(robot_plans drake::drake)
 target_include_directories(robot_plans PUBLIC ${PROJECT_SOURCE_DIR}/src)
 

--- a/src/plans/chicken_head_plan.cc
+++ b/src/plans/chicken_head_plan.cc
@@ -1,13 +1,44 @@
 #include "plans/chicken_head_plan.h"
 
-#include <utility>
+
 
 ChickenHeadPlan::ChickenHeadPlan(
-    drake::math::RigidTransformd X_WT0,
+    const drake::math::RigidTransformd& X_WL7_0,
     const drake::multibody::MultibodyPlant<double> *plant)
-    : PlanBase(plant), X_WT0_(std::move(X_WT0)),
+    : PlanBase(plant), X_WCd_(X_WL7_0 * X_L7T_),
       frame_L7_(plant->GetFrameByName("iiwa_link_7")) {
+  // X_TC subscription.
+  owned_lcm_ = std::make_unique<drake::lcm::DrakeLcm>();
+  rpe_sub_ = std::make_unique<drake::lcm::Subscriber<drake::lcmt_robot_state>>(
+      owned_lcm_.get(), "X_TC");
+  sub_thread_ = std::thread(&ChickenHeadPlan::ReceiveRelativePose, this);
+}
 
+ChickenHeadPlan::~ChickenHeadPlan() {
+  if (sub_thread_.joinable()) {
+    sub_thread_.join();
+  }
+}
 
+[[noreturn]] void ChickenHeadPlan::ReceiveRelativePose() const {
+  while (true) {
+    rpe_sub_->clear();
+    drake::lcm::LcmHandleSubscriptionsUntil(
+        owned_lcm_.get(), [&]() { return rpe_sub_->count() > 0; });
+    const auto& X_TC_msg = rpe_sub_->message();
+    const auto& q_xyz = X_TC_msg.joint_position;
+    const auto Q_TC = Eigen::Quaterniond(q_xyz[0], q_xyz[1], q_xyz[2],
+                                         q_xyz[3]);
+    const auto p_TC = Eigen::Vector3d(q_xyz[4], q_xyz[5], q_xyz[6]);
+    {
+      std::lock_guard<std::mutex> lock(mutex_rpe_);
+      X_TC_.set_rotation(Q_TC);
+      X_TC_.set_translation(p_TC);
+    }
+  }
+}
+
+void ChickenHeadPlan::Step(const State &state, double control_period, double t,
+          Command *cmd) const {
 
 }

--- a/src/plans/chicken_head_plan.cc
+++ b/src/plans/chicken_head_plan.cc
@@ -1,12 +1,25 @@
 #include "plans/chicken_head_plan.h"
 
-
+using drake::Vector6;
+using drake::math::RigidTransformd;
+using drake::manipulation::planner::internal::DoDifferentialInverseKinematics;
+using drake::manipulation::planner::DifferentialInverseKinematicsStatus;
 
 ChickenHeadPlan::ChickenHeadPlan(
-    const drake::math::RigidTransformd& X_WL7_0,
+    const drake::math::RigidTransformd &X_WL7_0, double duration,
+    double control_time_step,
+    const Eigen::Ref<const Eigen::VectorXd> &nominal_joint_angles,
     const drake::multibody::MultibodyPlant<double> *plant)
-    : PlanBase(plant), X_WCd_(X_WL7_0 * X_L7T_),
+    : PlanBase(plant), duration_(duration), X_WCd_(X_WL7_0 * X_L7T_),
       frame_L7_(plant->GetFrameByName("iiwa_link_7")) {
+  // DiffIk.
+  params_ = std::make_unique<
+      drake::manipulation::planner::DifferentialInverseKinematicsParameters>(
+      plant_->num_positions(), plant_->num_velocities());
+  params_->set_timestep(control_time_step);
+  params_->set_nominal_joint_position(nominal_joint_angles);
+  plant_context_ = plant_->CreateDefaultContext();
+
   // X_TC subscription.
   owned_lcm_ = std::make_unique<drake::lcm::DrakeLcm>();
   rpe_sub_ = std::make_unique<drake::lcm::Subscriber<drake::lcmt_robot_state>>(
@@ -15,20 +28,24 @@ ChickenHeadPlan::ChickenHeadPlan(
 }
 
 ChickenHeadPlan::~ChickenHeadPlan() {
-  if (sub_thread_.joinable()) {
-    sub_thread_.join();
-  }
+  stop_flag_ = true;
+  sub_thread_.join();
 }
 
-[[noreturn]] void ChickenHeadPlan::ReceiveRelativePose() const {
+void ChickenHeadPlan::ReceiveRelativePose() const {
+  int i = 0;
   while (true) {
     rpe_sub_->clear();
     drake::lcm::LcmHandleSubscriptionsUntil(
-        owned_lcm_.get(), [&]() { return rpe_sub_->count() > 0; });
-    const auto& X_TC_msg = rpe_sub_->message();
-    const auto& q_xyz = X_TC_msg.joint_position;
-    const auto Q_TC = Eigen::Quaterniond(q_xyz[0], q_xyz[1], q_xyz[2],
-                                         q_xyz[3]);
+        owned_lcm_.get(),
+        [&]() { return stop_flag_ or rpe_sub_->count() > 0; });
+    if (stop_flag_) {
+      break;
+    }
+    const auto &X_TC_msg = rpe_sub_->message();
+    const auto &q_xyz = X_TC_msg.joint_position;
+    const auto Q_TC =
+        Eigen::Quaterniond(q_xyz[0], q_xyz[1], q_xyz[2], q_xyz[3]);
     const auto p_TC = Eigen::Vector3d(q_xyz[4], q_xyz[5], q_xyz[6]);
     {
       std::lock_guard<std::mutex> lock(mutex_rpe_);
@@ -39,6 +56,39 @@ ChickenHeadPlan::~ChickenHeadPlan() {
 }
 
 void ChickenHeadPlan::Step(const State &state, double control_period, double t,
-          Command *cmd) const {
+                           Command *cmd) const {
+  RigidTransformd X_WTd;
+  {
+    std::lock_guard<std::mutex> lock(mutex_rpe_);
+    X_WTd = X_WCd_ * X_TC_.inverse();
+  }
 
+  // DiffIk.
+  plant_->SetPositions(plant_context_.get(), state.q);
+  const auto &frame_W = plant_->world_frame();
+  const auto X_WT =
+      plant_->CalcRelativeTransform(*plant_context_, frame_W, frame_L7_) *
+      X_L7T_;
+  const Vector6<double> V_WT_desired =
+      drake::manipulation::planner::ComputePoseDiffInCommonFrame(
+          X_WT.GetAsIsometry3(), X_WTd.GetAsIsometry3()) /
+      params_->get_timestep();
+
+  Eigen::MatrixXd J_WT(6, plant_->num_velocities());
+  plant_->CalcJacobianSpatialVelocity(
+      *plant_context_, drake::multibody::JacobianWrtVariable::kV, frame_L7_,
+      X_L7T_.translation(), frame_W, frame_W, &J_WT);
+
+  const auto result = DoDifferentialInverseKinematics(
+      state.q, state.v, X_WT, J_WT,
+      drake::multibody::SpatialVelocity<double>(V_WT_desired), *params_);
+
+  // 3. Check for errors and integrate.
+  if (result.status != DifferentialInverseKinematicsStatus::kSolutionFound) {
+    cmd->q_cmd = NAN * Eigen::VectorXd::Zero(7);
+    spdlog::critical("DoDifferentialKinematics Failed to find a solution.");
+  } else {
+    cmd->q_cmd = state.q + control_period * result.joint_velocities.value();
+    cmd->tau_cmd = Eigen::VectorXd::Zero(7);
+  }
 }

--- a/src/plans/chicken_head_plan.cc
+++ b/src/plans/chicken_head_plan.cc
@@ -1,0 +1,13 @@
+#include "plans/chicken_head_plan.h"
+
+#include <utility>
+
+ChickenHeadPlan::ChickenHeadPlan(
+    drake::math::RigidTransformd X_WT0,
+    const drake::multibody::MultibodyPlant<double> *plant)
+    : PlanBase(plant), X_WT0_(std::move(X_WT0)),
+      frame_L7_(plant->GetFrameByName("iiwa_link_7")) {
+
+
+
+}

--- a/src/plans/chicken_head_plan.cc
+++ b/src/plans/chicken_head_plan.cc
@@ -117,8 +117,7 @@ void ChickenHeadPlan::Step(const State &state, double control_period, double t,
 
   // 3. Check for errors and integrate.
   if (result.status != DifferentialInverseKinematicsStatus::kSolutionFound) {
-    cmd->q_cmd = NAN * Eigen::VectorXd::Zero(7);
-    spdlog::critical("DoDifferentialKinematics Failed to find a solution.");
+    throw DiffIkException();
   } else {
     cmd->q_cmd = state.q + control_period * result.joint_velocities.value();
     cmd->tau_cmd = Eigen::VectorXd::Zero(7);

--- a/src/plans/chicken_head_plan.h
+++ b/src/plans/chicken_head_plan.h
@@ -19,6 +19,7 @@
  * The plan subscribes to Relative Pose Estimator and receives X_TC.
  * The goal is to have T track Td (Tool_desired), so that
  *  X_WTd * X_TC = X_WCd.
+ *  Also publishes X_WC on the LCM channel "X_WC".
  */
 class ChickenHeadPlan : public PlanBase {
  public:
@@ -46,11 +47,12 @@ class ChickenHeadPlan : public PlanBase {
   params_;
 
   // Relative pose estimator subscription.
-  void ReceiveRelativePose() const;
+  void PoseIo() const;
   std::unique_ptr<drake::lcm::DrakeLcm> owned_lcm_;
   std::unique_ptr<drake::lcm::Subscriber<drake::lcmt_robot_state>> rpe_sub_;
   std::thread sub_thread_;
   std::atomic<bool> stop_flag_{false};
   mutable std::mutex mutex_rpe_;
   mutable drake::math::RigidTransformd X_TC_;
+  mutable drake::math::RigidTransformd X_WT_;
 };

--- a/src/plans/chicken_head_plan.h
+++ b/src/plans/chicken_head_plan.h
@@ -1,19 +1,46 @@
+#include <thread>
+
 #include "plans/plan_base.h"
 #include "drake/lcm/drake_lcm.h"
-
+#include "drake/lcmt_robot_state.hpp"
 #include <Eigen/Dense>
 
+/*
+ * Frame hierarchy:
+ * L7 --> T --> C
+ * L7 is the frame of link 7 of the IIWA.
+ * T is fixed relative to L7, called the tool frame.
+ * C is fixed to the tool handle, called the compliant frame.
+ * X_L7T is fixed and hard coded.
+ * X_WL7_0 is the pose of frame L7 at the beginning of the plan.
+ * Frame Cd (Compliant-desired) is initialized to be identical to T when the
+ *  plan is constructed: X_WT_0 == X_WCd
+ * The plan subscribes to Relative Pose Estimator and receives X_TC.
+ * The goal is to have T track Td (Tool_desired), so that
+ *  X_WTd * X_TC = X_WCd.
+ */
 class ChickenHeadPlan : public PlanBase {
  public:
-  ChickenHeadPlan(drake::math::RigidTransformd  X_WT0,
+  ChickenHeadPlan(const drake::math::RigidTransformd& X_WL7_0,
                   const drake::multibody::MultibodyPlant<double> *plant);
+  ~ChickenHeadPlan() override;
 
+  void Step(const State &state, double control_period, double t,
+            Command *cmd) const override;
  private:
-  const drake::math::RigidTransformd X_WT0_;
-  const drake::multibody::Frame<double>& frame_L7_;
+  [[noreturn]] void ReceiveRelativePose() const;
+
   // Relative transform between the frame L7 and the frame tool frame T.
   const drake::math::RigidTransformd X_L7T_ = drake::math::RigidTransformd(
       drake::math::RollPitchYawd(Eigen::Vector3d(0, -M_PI / 2, 0)),
       Eigen::Vector3d(0, 0, 0.255));
-  std::unique_ptr<drake::lcm::DrakeLcm> lcm_;
+  const drake::math::RigidTransformd X_WCd_;
+  const drake::multibody::Frame<double>& frame_L7_;
+
+  // Relative pose estimator subscription.
+  std::unique_ptr<drake::lcm::DrakeLcm> owned_lcm_;
+  std::unique_ptr<drake::lcm::Subscriber<drake::lcmt_robot_state>> rpe_sub_;
+  std::thread sub_thread_;
+  mutable std::mutex mutex_rpe_;
+  mutable drake::math::RigidTransformd X_TC_;
 };

--- a/src/plans/chicken_head_plan.h
+++ b/src/plans/chicken_head_plan.h
@@ -3,6 +3,7 @@
 #include "plans/plan_base.h"
 #include "drake/lcm/drake_lcm.h"
 #include "drake/lcmt_robot_state.hpp"
+#include "drake/manipulation/planner/differential_inverse_kinematics.h"
 #include <Eigen/Dense>
 
 /*
@@ -21,26 +22,35 @@
  */
 class ChickenHeadPlan : public PlanBase {
  public:
-  ChickenHeadPlan(const drake::math::RigidTransformd& X_WL7_0,
+  ChickenHeadPlan(const drake::math::RigidTransformd &X_WL7_0,
+                  double duration,
+                  double control_time_step,
+                  const Eigen::Ref<const Eigen::VectorXd> &nominal_joint_angles,
                   const drake::multibody::MultibodyPlant<double> *plant);
   ~ChickenHeadPlan() override;
 
   void Step(const State &state, double control_period, double t,
             Command *cmd) const override;
+  double duration() const override {return duration_;};
  private:
-  [[noreturn]] void ReceiveRelativePose() const;
-
+  const double duration_{0};
   // Relative transform between the frame L7 and the frame tool frame T.
   const drake::math::RigidTransformd X_L7T_ = drake::math::RigidTransformd(
       drake::math::RollPitchYawd(Eigen::Vector3d(0, -M_PI / 2, 0)),
       Eigen::Vector3d(0, 0, 0.255));
   const drake::math::RigidTransformd X_WCd_;
   const drake::multibody::Frame<double>& frame_L7_;
+  std::unique_ptr<drake::systems::Context<double>> plant_context_;
+  std::unique_ptr<
+  drake::manipulation::planner::DifferentialInverseKinematicsParameters>
+  params_;
 
   // Relative pose estimator subscription.
+  void ReceiveRelativePose() const;
   std::unique_ptr<drake::lcm::DrakeLcm> owned_lcm_;
   std::unique_ptr<drake::lcm::Subscriber<drake::lcmt_robot_state>> rpe_sub_;
   std::thread sub_thread_;
+  std::atomic<bool> stop_flag_{false};
   mutable std::mutex mutex_rpe_;
   mutable drake::math::RigidTransformd X_TC_;
 };

--- a/src/plans/chicken_head_plan.h
+++ b/src/plans/chicken_head_plan.h
@@ -4,6 +4,8 @@
 #include "drake/lcm/drake_lcm.h"
 #include "drake/lcmt_robot_state.hpp"
 #include "drake/manipulation/planner/differential_inverse_kinematics.h"
+#include "drake/solvers/gurobi_solver.h"
+#include "drake/solvers/mathematical_program.h"
 #include <Eigen/Dense>
 
 /*
@@ -25,8 +27,6 @@ class ChickenHeadPlan : public PlanBase {
  public:
   ChickenHeadPlan(const drake::math::RigidTransformd &X_WL7_0,
                   double duration,
-                  double control_time_step,
-                  const Eigen::Ref<const Eigen::VectorXd> &nominal_joint_angles,
                   const drake::multibody::MultibodyPlant<double> *plant);
   ~ChickenHeadPlan() override;
 
@@ -41,10 +41,14 @@ class ChickenHeadPlan : public PlanBase {
       Eigen::Vector3d(0, 0, 0.255));
   const drake::math::RigidTransformd X_WCd_;
   const drake::multibody::Frame<double>& frame_L7_;
+
+  // DiffIk
+  const Eigen::Array3d kp_translation_{100, 100, 100};
+  const Eigen::Array3d kp_rotation_{50, 50, 50};
+  mutable Eigen::MatrixXd Jv_WTq_W_{6, 7};
   std::unique_ptr<drake::systems::Context<double>> plant_context_;
-  std::unique_ptr<
-  drake::manipulation::planner::DifferentialInverseKinematicsParameters>
-  params_;
+  std::unique_ptr<drake::solvers::GurobiSolver> solver_;
+  std::unique_ptr<drake::solvers::MathematicalProgramResult> result_;
 
   // Relative pose estimator subscription.
   void PoseIo() const;

--- a/src/plans/chicken_head_plan.h
+++ b/src/plans/chicken_head_plan.h
@@ -1,0 +1,19 @@
+#include "plans/plan_base.h"
+#include "drake/lcm/drake_lcm.h"
+
+#include <Eigen/Dense>
+
+class ChickenHeadPlan : public PlanBase {
+ public:
+  ChickenHeadPlan(drake::math::RigidTransformd  X_WT0,
+                  const drake::multibody::MultibodyPlant<double> *plant);
+
+ private:
+  const drake::math::RigidTransformd X_WT0_;
+  const drake::multibody::Frame<double>& frame_L7_;
+  // Relative transform between the frame L7 and the frame tool frame T.
+  const drake::math::RigidTransformd X_L7T_ = drake::math::RigidTransformd(
+      drake::math::RollPitchYawd(Eigen::Vector3d(0, -M_PI / 2, 0)),
+      Eigen::Vector3d(0, 0, 0.255));
+  std::unique_ptr<drake::lcm::DrakeLcm> lcm_;
+};

--- a/src/plans/iiwa_plan_factory.cc
+++ b/src/plans/iiwa_plan_factory.cc
@@ -17,6 +17,9 @@ using std::endl;
 using std::vector;
 
 IiwaPlanFactory::IiwaPlanFactory(const YAML::Node &config) : config_(config) {
+  // Constructs a MultibodyPlant contianing on the IIWA robot with its link 0
+  // welded to the world frame. This is the plant to be used by all Plans
+  // constructed by this factory, if the plan needs a plant.
   plant_ = std::make_unique<drake::multibody::MultibodyPlant<double>>(1e-3);
   auto parser = drake::multibody::Parser(plant_.get());
 

--- a/src/plans/iiwa_plan_factory.cc
+++ b/src/plans/iiwa_plan_factory.cc
@@ -128,10 +128,7 @@ std::unique_ptr<PlanBase> IiwaPlanFactory::MakeTaskSpaceTrajectoryPlan(
   const double duration = msg_plan.plan.at(1).utime / 1e6;
   const auto nominal_joint_vector =
       config_["robot_nominal_joint"].as<vector<double>>();
-  auto nominal_joint = Eigen::Map<const Eigen::VectorXd>(
-      nominal_joint_vector.data(), nominal_joint_vector.size());
   return std::make_unique<ChickenHeadPlan>(
       TransformFromRobotStateMsg(msg_plan.plan[0].joint_position), duration,
-      config_["control_period"].as<double>(), nominal_joint,
       plant_.get());
 }

--- a/src/plans/iiwa_plan_factory.cc
+++ b/src/plans/iiwa_plan_factory.cc
@@ -4,6 +4,7 @@
 #include "drake/common/trajectories/piecewise_quaternion.h"
 #include "drake/multibody/parsing/parser.h"
 
+#include "chicken_head_plan.h"
 #include "joint_space_trajectory_plan.h"
 #include "task_space_trajectory_plan.h"
 
@@ -36,10 +37,14 @@ std::unique_ptr<PlanBase>
 IiwaPlanFactory::MakePlan(const drake::lcmt_robot_plan &msg_plan) const {
   // TODO: replace this with a better test and use an lcm type with an
   //  enum for plan types?
-  if (msg_plan.plan.at(0).joint_name.at(0) == "iiwa_joint_0") {
+  const auto first_joint_name =
+      std::string(msg_plan.plan.at(0).joint_name.at(0));
+  if (first_joint_name == "iiwa_joint_0") {
     return MakeJointSpaceTrajectoryPlan(msg_plan);
-  } else if (msg_plan.plan.at(0).joint_name.at(0) == "qw") {
+  } else if (first_joint_name == "qw") {
     return MakeTaskSpaceTrajectoryPlan(msg_plan);
+  } else if (first_joint_name == "qw_chicken") {
+    return MakeChickenHeadPlan(msg_plan);
   }
   throw std::runtime_error("error in plan lcm message.");
 }
@@ -52,7 +57,7 @@ std::unique_ptr<PlanBase> IiwaPlanFactory::MakeJointSpaceTrajectoryPlan(
   VectorXd t_knots(n_knots);
 
   for (int t = 0; t < n_knots; t++) {
-    t_knots[t] = static_cast<double>(msg_plan.plan.at(t).utime) / 1e6;
+    t_knots[t] = msg_plan.plan.at(t).utime / 1e6;
     for (int i = 0; i < n_q; i++) {
       q_knots(i, t) = msg_plan.plan.at(t).joint_position.at(i);
     }
@@ -70,11 +75,8 @@ std::unique_ptr<PlanBase> IiwaPlanFactory::MakeTaskSpaceTrajectoryPlan(
   int n_knots = msg_plan.num_states - 1;
 
   // X_ET.
-  const auto& q_xyz_ET = msg_plan.plan[n_knots].joint_position;
-  const auto Q_ET = Quaterniond(q_xyz_ET[0], q_xyz_ET[1], q_xyz_ET[2],
-                                q_xyz_ET[3]);
-  const auto p_EoTo_E = Eigen::Vector3d(q_xyz_ET[4], q_xyz_ET[5], q_xyz_ET[6]);
-  const auto X_ET = drake::math::RigidTransform<double>(Q_ET, p_EoTo_E);
+  const auto &q_xyz_ET = msg_plan.plan[n_knots].joint_position;
+  const auto X_ET = TransformFromRobotStateMsg(q_xyz_ET);
 
   // trajectory.
   vector<double> t_knots(n_knots);
@@ -83,9 +85,9 @@ std::unique_ptr<PlanBase> IiwaPlanFactory::MakeTaskSpaceTrajectoryPlan(
 
   for (int t = 0; t < n_knots; t++) {
     // Store time
-    t_knots[t] = static_cast<double>(msg_plan.plan.at(t).utime) / 1e6;
+    t_knots[t] = msg_plan.plan.at(t).utime / 1e6;
     // Store quaternions
-    const auto& q_xyz = msg_plan.plan.at(t).joint_position;
+    const auto &q_xyz = msg_plan.plan.at(t).joint_position;
     quat_knots[t] = Quaterniond(q_xyz[0], q_xyz[1], q_xyz[2], q_xyz[3]);
 
     // Store xyz positions.
@@ -108,14 +110,28 @@ std::unique_ptr<PlanBase> IiwaPlanFactory::MakeTaskSpaceTrajectoryPlan(
   const auto &frame_E =
       plant_->GetFrameByName(config_["robot_ee_body_name"].as<std::string>());
 
-  vector<double> nominal_joint_vector = 
-    config_["robot_nominal_joint"].as<vector<double>>();
-
-  Eigen::VectorXd nominal_joint= Eigen::Map<Eigen::VectorXd, Eigen::Unaligned>(
-    nominal_joint_vector.data(), nominal_joint_vector.size());
-
+  // TODO(pang): it feels like the nominal joint angles should be part of the
+  //  plan definition, not in the config file.
+  const auto nominal_joint_vector =
+      config_["robot_nominal_joint"].as<vector<double>>();
+  auto nominal_joint = Eigen::Map<const Eigen::VectorXd>(
+      nominal_joint_vector.data(), nominal_joint_vector.size());
 
   return std::make_unique<TaskSpaceTrajectoryPlan>(
       std::move(quat_traj), std::move(xyz_traj), X_ET, plant_.get(), frame_E,
       config_["control_period"].as<double>(), nominal_joint);
+}
+
+[[nodiscard]] std::unique_ptr<PlanBase> IiwaPlanFactory::MakeChickenHeadPlan(
+    const drake::lcmt_robot_plan &msg_plan) const {
+  DRAKE_THROW_UNLESS(msg_plan.plan.size() == 2);
+  const double duration = msg_plan.plan.at(1).utime / 1e6;
+  const auto nominal_joint_vector =
+      config_["robot_nominal_joint"].as<vector<double>>();
+  auto nominal_joint = Eigen::Map<const Eigen::VectorXd>(
+      nominal_joint_vector.data(), nominal_joint_vector.size());
+  return std::make_unique<ChickenHeadPlan>(
+      TransformFromRobotStateMsg(msg_plan.plan[0].joint_position), duration,
+      config_["control_period"].as<double>(), nominal_joint,
+      plant_.get());
 }

--- a/src/plans/iiwa_plan_factory.h
+++ b/src/plans/iiwa_plan_factory.h
@@ -13,9 +13,25 @@ public:
   MakePlan(const drake::lcmt_robot_plan &msg_plan) const override;
 
 private:
+  // q_xyz.size() == 7. q_xyz[0:4] are the w, x, y and z components of the
+  // quaternion. q_xyz[4:7] are the x, y and z components of the translation.
+  template <class T>
+  static drake::math::RigidTransformd TransformFromRobotStateMsg(
+      const std::vector<T>& q_xyz);
   const YAML::Node &config_;
   [[nodiscard]] std::unique_ptr<PlanBase>
   MakeJointSpaceTrajectoryPlan(const drake::lcmt_robot_plan &msg_plan) const;
   [[nodiscard]] std::unique_ptr<PlanBase>
   MakeTaskSpaceTrajectoryPlan(const drake::lcmt_robot_plan &msg_plan) const;
+  [[nodiscard]] std::unique_ptr<PlanBase>
+  MakeChickenHeadPlan(const drake::lcmt_robot_plan &msg_plan) const;
 };
+
+template <class T>
+drake::math::RigidTransformd IiwaPlanFactory::TransformFromRobotStateMsg(
+    const std::vector<T>& q_xyz) {
+  DRAKE_THROW_UNLESS(q_xyz.size() == 7);
+  const auto Q = Eigen::Quaterniond(q_xyz[0], q_xyz[1], q_xyz[2], q_xyz[3]);
+  const auto p = Eigen::Vector3d(q_xyz[4], q_xyz[5], q_xyz[6]);
+  return {Q, p};
+}

--- a/src/plans/plan_base.h
+++ b/src/plans/plan_base.h
@@ -6,14 +6,6 @@
 #include "drake/multibody/plant/multibody_plant.h"
 #include <Eigen/Dense>
 
-// Description of a single contact.
-struct ContactInfo {
-  Eigen::Vector3d contact_force;                 // in world frame.
-  Eigen::Vector3d contact_point;                 // in world frame.
-  drake::multibody::BodyIndex contact_link_idx;  // tied to a specific MBP.
-  std::optional<Eigen::Vector3d> contact_normal; // in world frame?
-};
-
 struct State {
   State() = default;
   State(const Eigen::Ref<const Eigen::VectorXd> &q,
@@ -23,7 +15,6 @@ struct State {
   Eigen::VectorXd q;
   Eigen::VectorXd v;
   Eigen::VectorXd tau_ext;
-  std::optional<std::vector<ContactInfo>> contact_results;
 };
 
 struct Command {
@@ -48,5 +39,7 @@ public:
   [[nodiscard]] virtual double duration() const = 0;
 
 protected:
+  // If a child Plan needs an MBP of the robot, it needs to get it from the
+  // Factory which constructs the Plan.
   drake::multibody::MultibodyPlant<double> const *const plant_{nullptr};
 };

--- a/src/plans/plan_base.h
+++ b/src/plans/plan_base.h
@@ -26,6 +26,29 @@ struct Command {
   Eigen::VectorXd tau_cmd;
 };
 
+struct PlanException : public std::exception {
+  [[nodiscard]] const char* what() const noexcept override = 0;
+};
+
+struct NanException : PlanException {
+  [[nodiscard]] const char* what() const noexcept override {
+    return "Joint angle commands contain Nan.";
+  }
+};
+
+struct TooFarAwayException : PlanException {
+  [[nodiscard]] const char* what() const noexcept override {
+    return "Difference between commanded and measured joint angles are too "
+           "large.";
+  }
+};
+
+struct DiffIkException : PlanException {
+  [[nodiscard]] const char* what() const noexcept override {
+    return "Differential inverse kinematics failed to find a solution.";
+  }
+};
+
 class PlanBase {
 public:
   explicit PlanBase(const drake::multibody::MultibodyPlant<double> *plant)

--- a/src/plans/task_space_trajectory_plan.cc
+++ b/src/plans/task_space_trajectory_plan.cc
@@ -56,15 +56,7 @@ void TaskSpaceTrajectoryPlan::Step(const State &state, double control_period,
 
   // 3. Check for errors and integrate.
   if (result.status != DifferentialInverseKinematicsStatus::kSolutionFound) {
-    // Set the command to NAN so that state machine will detect downstream and
-    // go to error state.
-    cmd->q_cmd = NAN * Eigen::VectorXd::Zero(7);
-    // TODO(terry-suh): how do I tell the use that the state machine went to
-    //  error because of this precise reason? Printing the error message here
-    //  seems like a good start, but we'll need to handle this better.
-    //  (Pang): I think throwing exceptions here and have them handled at the
-    //   level of PlanManager is a good solution.
-    spdlog::critical("DoDifferentialKinematics Failed to find a solution.");
+    throw DiffIkException();
   } else {
     cmd->q_cmd = state.q + control_period * result.joint_velocities.value();
     cmd->tau_cmd = Eigen::VectorXd::Zero(7);

--- a/src/plans/task_space_trajectory_plan.cc
+++ b/src/plans/task_space_trajectory_plan.cc
@@ -1,15 +1,33 @@
 #include "task_space_trajectory_plan.h"
 
+using drake::MatrixX;
+using drake::Vector3;
+using drake::Vector6;
+using drake::manipulation::planner::ComputePoseDiffInCommonFrame;
 using drake::manipulation::planner::DifferentialInverseKinematicsResult;
 using drake::manipulation::planner::DifferentialInverseKinematicsStatus;
 using drake::manipulation::planner::internal::DoDifferentialInverseKinematics;
-using drake::manipulation::planner::ComputePoseDiffInCommonFrame;
-using drake::Vector3;
-using drake::Vector6;
-using drake::MatrixX;
 
 using std::cout;
 using std::endl;
+
+TaskSpaceTrajectoryPlan::TaskSpaceTrajectoryPlan(
+    drake::trajectories::PiecewiseQuaternionSlerp<double> quat_traj,
+    drake::trajectories::PiecewisePolynomial<double> xyz_traj,
+    drake::math::RigidTransformd X_ET,
+    const drake::multibody::MultibodyPlant<double> *plant,
+    const drake::multibody::Frame<double> &frame_E, double control_time_step,
+    Eigen::VectorXd nominal_joint_position)
+    : PlanBase(plant), quat_traj_(std::move(quat_traj)), X_ET_(std::move(X_ET)),
+      xyz_traj_(std::move(xyz_traj)), frame_E_(frame_E) {
+
+  params_ = std::make_unique<
+      drake::manipulation::planner::DifferentialInverseKinematicsParameters>(
+      plant_->num_positions(), plant_->num_velocities());
+  params_->set_timestep(control_time_step);
+  params_->set_nominal_joint_position(nominal_joint_position);
+  plant_context_ = plant_->CreateDefaultContext();
+}
 
 void TaskSpaceTrajectoryPlan::Step(const State &state, double control_period,
                                    double t, Command *cmd) const {
@@ -19,23 +37,21 @@ void TaskSpaceTrajectoryPlan::Step(const State &state, double control_period,
 
   // 2. Ask diffik to solve for desired position.
   const drake::math::RigidTransformd X_WT_desired(quat_traj_.orientation(t),
-                                            xyz_traj_.value(t));
-  const auto& frame_W = plant_->world_frame();
-  const auto X_WE = plant_->CalcRelativeTransform(
-      *plant_context_, frame_W, frame_E_);
+                                                  xyz_traj_.value(t));
+  const auto &frame_W = plant_->world_frame();
+  const auto X_WE =
+      plant_->CalcRelativeTransform(*plant_context_, frame_W, frame_E_);
   const auto X_WT = X_WE * X_ET_;
 
   const Vector6<double> V_WT_desired =
-      ComputePoseDiffInCommonFrame(
-          X_WT.GetAsIsometry3(), X_WT_desired.GetAsIsometry3()) /
-          params_->get_timestep();
+      ComputePoseDiffInCommonFrame(X_WT.GetAsIsometry3(),
+                                   X_WT_desired.GetAsIsometry3()) /
+      params_->get_timestep();
 
   MatrixX<double> J_WT(6, plant_->num_velocities());
-  plant_->CalcJacobianSpatialVelocity(*plant_context_,
-                                    drake::multibody::JacobianWrtVariable::kV,
-                                    frame_E_, X_ET_.translation(),
-                                    frame_W, frame_W, &J_WT);
-
+  plant_->CalcJacobianSpatialVelocity(
+      *plant_context_, drake::multibody::JacobianWrtVariable::kV, frame_E_,
+      X_ET_.translation(), frame_W, frame_W, &J_WT);
 
   DifferentialInverseKinematicsResult result = DoDifferentialInverseKinematics(
       state.q, state.v, X_WT, J_WT,

--- a/src/plans/task_space_trajectory_plan.h
+++ b/src/plans/task_space_trajectory_plan.h
@@ -38,7 +38,6 @@ private:
 
   // frame of end-effector body + offset.
   const drake::multibody::Frame<double> &frame_E_;
-
   std::unique_ptr<drake::systems::Context<double>> plant_context_;
   std::unique_ptr<
       drake::manipulation::planner::DifferentialInverseKinematicsParameters>

--- a/src/plans/task_space_trajectory_plan.h
+++ b/src/plans/task_space_trajectory_plan.h
@@ -20,10 +20,11 @@ public:
       drake::math::RigidTransformd X_ET,
       const drake::multibody::MultibodyPlant<double> *plant,
       const drake::multibody::Frame<double> &frame_E,
-      double control_time_step, Eigen::VectorXd nominal_joint_position)
+      double control_time_step,
+      Eigen::VectorXd nominal_joint_position)
       : PlanBase(plant), quat_traj_(std::move(quat_traj)),
         X_ET_(std::move(X_ET)), xyz_traj_(std::move(xyz_traj)),
-        frame_E_(frame_E), nominal_joint_position_(nominal_joint_position) {
+        frame_E_(frame_E) {
 
     params_ = std::make_unique<
         drake::manipulation::planner::DifferentialInverseKinematicsParameters>(
@@ -46,7 +47,6 @@ private:
   const drake::trajectories::PiecewiseQuaternionSlerp<double> quat_traj_;
   const drake::trajectories::PiecewisePolynomial<double> xyz_traj_;
   const drake::math::RigidTransformd X_ET_;
-  const Eigen::VectorXd nominal_joint_position_;
 
   // frame of end-effector body + offset.
   const drake::multibody::Frame<double> &frame_E_;

--- a/src/plans/task_space_trajectory_plan.h
+++ b/src/plans/task_space_trajectory_plan.h
@@ -19,20 +19,8 @@ public:
       drake::trajectories::PiecewisePolynomial<double> xyz_traj,
       drake::math::RigidTransformd X_ET,
       const drake::multibody::MultibodyPlant<double> *plant,
-      const drake::multibody::Frame<double> &frame_E,
-      double control_time_step,
-      Eigen::VectorXd nominal_joint_position)
-      : PlanBase(plant), quat_traj_(std::move(quat_traj)),
-        X_ET_(std::move(X_ET)), xyz_traj_(std::move(xyz_traj)),
-        frame_E_(frame_E) {
-
-    params_ = std::make_unique<
-        drake::manipulation::planner::DifferentialInverseKinematicsParameters>(
-        plant_->num_positions(), plant_->num_velocities());
-    params_->set_timestep(control_time_step);
-    params_->set_nominal_joint_position(nominal_joint_position);
-    plant_context_ = plant_->CreateDefaultContext();
-  }
+      const drake::multibody::Frame<double> &frame_E, double control_time_step,
+      Eigen::VectorXd nominal_joint_position);
 
   ~TaskSpaceTrajectoryPlan() override = default;
 

--- a/src/state_machine/plan_manager_state_machine.cc
+++ b/src/state_machine/plan_manager_state_machine.cc
@@ -55,7 +55,6 @@ bool PlanManagerStateBase::CommandHasError(
       cmd.q_cmd.array().isNaN().sum() or cmd.tau_cmd.array().isNaN().sum();
 
   bool is_too_far_away = (state.q - cmd.q_cmd).norm() > q_threshold;
-
   bool is_error = is_nan or is_too_far_away;
   if (is_error) {
     while (!state_machine->plans_.empty()) {

--- a/src/state_machine/plan_manager_state_machine.cc
+++ b/src/state_machine/plan_manager_state_machine.cc
@@ -48,22 +48,28 @@ void PlanManagerStateBase::QueueNewPlan(PlanManagerStateMachine *state_machine,
   throw std::runtime_error(error_msg);
 }
 
-bool PlanManagerStateBase::CommandHasError(
+void PlanManagerStateBase::CheckCommandForError(
     const State &state, const Command &cmd,
     PlanManagerStateMachine *state_machine, const double q_threshold) {
   bool is_nan =
       cmd.q_cmd.array().isNaN().sum() or cmd.tau_cmd.array().isNaN().sum();
-
-  bool is_too_far_away = (state.q - cmd.q_cmd).norm() > q_threshold;
-  bool is_error = is_nan or is_too_far_away;
-  if (is_error) {
-    while (!state_machine->plans_.empty()) {
-      // Delete all plans.
-      state_machine->plans_.pop();
-    }
-    ChangeState(state_machine, StateError::Instance());
+  if (is_nan) {
+    throw NanException();
   }
-  return is_error;
+
+  const double dq_norm = (state.q - cmd.q_cmd).norm();
+  if (dq_norm > q_threshold) {
+    throw TooFarAwayException();
+  }
+}
+
+void PlanManagerStateBase::EnterErrorState(
+    PlanManagerStateMachine *state_machine) {
+  while (!state_machine->plans_.empty()) {
+    // Delete all plans.
+    state_machine->plans_.pop();
+  }
+  ChangeState(state_machine, StateError::Instance());
 }
 
 bool PlanManagerStateBase::has_received_status_msg() const {

--- a/src/state_machine/state_error.cc
+++ b/src/state_machine/state_error.cc
@@ -11,10 +11,17 @@ PlanManagerStateBase *StateError::Instance() {
   return instance_;
 }
 
-bool StateError::CommandHasError(const State &state, const Command &cmd,
-                     PlanManagerStateMachine *state_machine,
-                     const double q_threshold) {
-  std::string error_msg = "CommandHasError should not be called in state ";
+void StateError::CheckCommandForError(const State &state, const Command &cmd,
+                                      PlanManagerStateMachine *state_machine,
+                                      const double q_threshold) {
+  std::string error_msg = "CheckCommandForError should not be called in state ";
+  error_msg += get_state_name();
+  error_msg += ".";
+  throw std::runtime_error(error_msg);
+}
+
+void StateError::EnterErrorState(PlanManagerStateMachine *state_machine) {
+  std::string error_msg = "EnterErrorState should not be called in state ";
   error_msg += get_state_name();
   error_msg += ".";
   throw std::runtime_error(error_msg);

--- a/src/state_machine/state_error.h
+++ b/src/state_machine/state_error.h
@@ -8,9 +8,11 @@ public:
   void QueueNewPlan(PlanManagerStateMachine *state_machine,
                     std::unique_ptr<PlanBase> plan) override;
 
-  bool CommandHasError(const State &state, const Command &cmd,
-                       PlanManagerStateMachine *state_machine,
-                       const double q_threshold) override;
+  void CheckCommandForError(const State &state, const Command &cmd,
+                            PlanManagerStateMachine *state_machine,
+                            const double q_threshold) override;
+
+  void EnterErrorState(PlanManagerStateMachine *state_machine) override;
 
   void PrintCurrentState(const PlanManagerStateMachine *state_machine,
                          double t_now_seconds) const override;

--- a/src/state_machine/state_init.cc
+++ b/src/state_machine/state_init.cc
@@ -27,10 +27,10 @@ void StateInit::QueueNewPlan(PlanManagerStateMachine *state_machine,
                "Received plan is discarded.");
 }
 
-bool StateInit::CommandHasError(const State &state, const Command &cmd,
-                                PlanManagerStateMachine *state_machine,
-                                const double q_threshold) {
-  std::string error_msg = "CommandHasError should not be called in state ";
+void StateInit::CheckCommandForError(const State &state, const Command &cmd,
+                                     PlanManagerStateMachine *state_machine,
+                                     const double q_threshold) {
+  std::string error_msg = "CheckCommandForError should not be called in state ";
   error_msg += get_state_name();
   error_msg += ".";
   throw std::runtime_error(error_msg);

--- a/src/state_machine/state_init.h
+++ b/src/state_machine/state_init.h
@@ -14,9 +14,9 @@ public:
   void QueueNewPlan(PlanManagerStateMachine *state_machine,
                     std::unique_ptr<PlanBase> plan) override;
 
-  bool CommandHasError(const State &state, const Command &cmd,
-                       PlanManagerStateMachine *state_machine,
-                       const double q_threshold) override;
+  void CheckCommandForError(const State &state, const Command &cmd,
+                            PlanManagerStateMachine *state_machine,
+                            const double q_threshold) override;
 
   void PrintCurrentState(const PlanManagerStateMachine *manager,
                          double t_now_seconds) const override;


### PR DESCRIPTION
A plan that keeps an imaginary frame's pose constant in world frame, based on measurements of the relative transform between the imaginary frame and the end effector frame.

Establishes a pattern for subscribing to additional lcm channels in the Plan and properly terminating them in the destructor of that Plan.

Also addresses a few long-standing issues, including #17 and #30. 