### PR TITLE
update posediff to not use isometry

### DIFF
--- a/src/plans/task_space_trajectory_plan.cc
+++ b/src/plans/task_space_trajectory_plan.cc
@@ -26,9 +26,8 @@ void TaskSpaceTrajectoryPlan::Step(const State &state, double control_period,
   const auto X_WT = X_WE * X_ET_;
 
   const Vector6<double> V_WT_desired =
-      ComputePoseDiffInCommonFrame(
-          X_WT.GetAsIsometry3(), X_WT_desired.GetAsIsometry3()) /
-          params_->get_timestep();
+      ComputePoseDiffInCommonFrame(X_WT, X_WT_desired) /
+      params_->get_timestep();
 
   MatrixX<double> J_WT(6, plant_->num_velocities());
   plant_->CalcJacobianSpatialVelocity(*plant_context_,


### PR DESCRIPTION
The syntax for `ComputePoseDiff` has changed to directly accept `RigidTransform` as opposed to Eigen Isometries. Results in build failure and fixed by this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/robot-plan-runner/46)
<!-- Reviewable:end -->
