### PR TITLE
Fix bionic CI failure

### DIFF
--- a/bionic.dockerfile
+++ b/bionic.dockerfile
@@ -9,8 +9,8 @@ RUN apt-get update && yes "Y" \
       && apt-get clean all
 
 # install drake.
-ENV DRAKE_URL=https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-bionic.tar.gz
-RUN curl -o drake.tar.gz $DRAKE_URL
+ENV DRAKE_URL=https://github.com/RobotLocomotion/drake/releases/download/v1.1.0/drake-20220328-bionic.tar.gz
+RUN curl -L -o drake.tar.gz $DRAKE_URL
 RUN tar -xzf drake.tar.gz -C /opt && rm drake.tar.gz
 RUN apt-get update \
   && yes "Y" | bash /opt/drake/share/drake/setup/install_prereqs \


### PR DESCRIPTION
Drake deletes nightly build tars 45 days after they are created and since Drake no longer supports Bionic, CI should switch to using the last release that supports Bionic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/robot-plan-runner/48)
<!-- Reviewable:end -->
